### PR TITLE
fix issue #70 in token.py

### DIFF
--- a/ppci/arch/token.py
+++ b/ppci/arch/token.py
@@ -24,7 +24,10 @@ def u64(x):
 
 
 def u8(x):
-    return struct.pack("<B", x)
+    if x < 0:
+        return struct.pack("<b", x)
+    else:
+        return struct.pack("<B", x)
 
 
 class _p2(property):


### PR DESCRIPTION
Fix issue #73.
It makes the u8 function accept negative value as for u16, u32 and u64.