### PR TITLE
Fix issue89

### DIFF
--- a/ppci/lang/c/semantics.py
+++ b/ppci/lang/c/semantics.py
@@ -669,15 +669,15 @@ class CSemantics:
                 long_type = self.get_type(["long"])
                 uint_type = self.get_type(["unsigned", "int"])
 
-                if value < self.context.limit_max(self.int_type):
+                if value <= self.context.limit_max(self.int_type):
                     typ = self.int_type
-                elif value < self.context.limit_max(uint_type):
+                elif value <= self.context.limit_max(uint_type):
                     typ = uint_type
-                elif value < self.context.limit_max(long_type):
+                elif value <= self.context.limit_max(long_type):
                     typ = long_type
-                elif value < self.context.limit_max(ulong_type):
+                elif value <= self.context.limit_max(ulong_type):
                     typ = ulong_type
-                elif value < self.context.limit_max(longlong_type):
+                elif value <= self.context.limit_max(longlong_type):
                     typ = longlong_type
                 else:
                     typ = ulonglong_type


### PR DESCRIPTION
In semantics.py/on_number(), the tests against the maximum values are changed from < to <= to
allow the maximum value.