### PR TITLE
Add darwin check in get_current_arch

### DIFF
--- a/ppci/arch/__init__.py
+++ b/ppci/arch/__init__.py
@@ -36,7 +36,7 @@ def get_current_arch():
         machine = platform.machine()
         if machine == "AMD64":
             return get_arch("x86_64:wincc")
-    elif sys.platform == "linux":
+    elif sys.platform in ("linux", "darwin"):
         if platform.architecture()[0] == "64bit":
             return get_arch("x86_64")
 


### PR DESCRIPTION
Adds check for `darwin` in `get_current_arch`. I was expecting more resistance to getting this going, but its pure Python nature made it a simple one-line change.

Local testing with `LONGTEST=python,any pytest -vv test/` shows `1509 passed, 634 skipped in 46.44s`

Running the example executable from `ppci-cc`/`-ld` works fine with Docker:

<details>
<summary>Example test on darwin</summary>

```
$ uname -a
Darwin klauer-osx 19.4.0 Darwin Kernel Version 19.4.0: Wed Mar  4 22:28:40 PST 2020; root:xnu-6153.101.6~15/RELEASE_X86_64 x86_64

$ ppci-cc -c -O1 -o hello.o hello.c
2020-07-10 10:36:40,408 |     INFO |       root | ppci 0.5.9 on CPython 3.7.6 on Darwin-19.4.0-x86_64-i386-64bit
2020-07-10 10:36:40,414 |     INFO |   cbuilder | Starting C compilation (c99)
2020-07-10 10:36:40,426 |     INFO |    cparser | Parsing finished
2020-07-10 10:36:40,429 |  WARNING |   ccodegen | Function does not return a value
2020-07-10 10:36:40,429 |     INFO |   ccodegen | Finished IR-code generation
2020-07-10 10:36:40,429 |     INFO |   optimize | Optimizing module main level 1
2020-07-10 10:36:40,442 |     INFO |    codegen | Generating x86_64-arch code for module main
2020-07-10 10:36:40,442 |     INFO |    codegen | Generating x86_64-arch code for function puts
2020-07-10 10:36:40,451 |     INFO |    codegen | Generating x86_64-arch code for function putc
2020-07-10 10:36:40,457 |     INFO |    codegen | Generating x86_64-arch code for function exit
2020-07-10 10:36:40,463 |     INFO |    codegen | Generating x86_64-arch code for function syscall
2020-07-10 10:36:40,513 |     INFO |    codegen | Generating x86_64-arch code for function main
2020-07-10 10:36:40,519 |  WARNING |       root | TODO: Linking with stdlibs

$ ppci-ld --entry main --layout linux64.ld hello.o -o hello
2020-07-10 10:36:52,463 |     INFO |       root | ppci 0.5.9 on CPython 3.7.6 on Darwin-19.4.0-x86_64-i386-64bit

$ cat Dockerfile
FROM quay.io/pypa/manylinux1_x86_64
COPY hello hello
RUN ./hello

$ docker build --no-cache .
Sending build context to Docker daemon  22.02kB
Step 1/3 : FROM quay.io/pypa/manylinux1_x86_64
 ---> 3317c29096eb
Step 2/3 : COPY hello hello
 ---> 97b527157f53
Step 3/3 : RUN ./hello
 ---> Running in ee23dd034fc2
Hello, World!
Removing intermediate container ee23dd034fc2
 ---> 294963088815
Successfully built 294963088815
```

</details>