### PR TITLE
FIX: uniformly handle string/numeric constants in multiple Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: python
 
 python:
@@ -6,6 +6,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
   # - "pypy3"
 
 install: pip -q install tox codacy-coverage codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
-dist: bionic
 language: python
+os: linux
+dist: bionic
 
-python:
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7"
-  - "3.8"
-  # - "pypy3"
+jobs:
+  include:
+    - dist: xenial
+      python: 3.4
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+    - python: 3.8
+    # - python: pypy3
 
 install: pip -q install tox codacy-coverage codecov
 

--- a/ppci/lang/python/python2ir.py
+++ b/ppci/lang/python/python2ir.py
@@ -461,7 +461,8 @@ class PythonToIrCompiler:
                 value = self.gen_name(expr)
             elif isinstance(expr, ast.Call):
                 value = self.gen_call(expr)
-            elif isinstance(expr, ast.Constant):  # Python 3.8+
+            elif hasattr(ast, 'Constant') and isinstance(expr, ast.Constant):
+                # Exists in Python 3.6+, generated in Python 3.8+
                 if isinstance(expr.value, str):
                     value = self.gen_string_constant(expr)
                 elif isinstance(expr.value, (int, float)):

--- a/test/lang/test_python.py
+++ b/test/lang/test_python.py
@@ -52,7 +52,14 @@ src6 = """
 def p1(a: int):
     if a > 2:
         return
-    
+
+"""
+
+src7 = """
+def p1(a: str):
+    if a == '3':
+        return
+
 """
 
 
@@ -128,6 +135,9 @@ class PythonToIrCompilerTestCase(unittest.TestCase):
 
     def test_snippet6(self):
         self.do(src6)
+
+    def test_snippet7(self):
+        self.do(src7)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Referring to [greentreesnakes](https://greentreesnakes.readthedocs.io/en/latest/nodes.html#Constant), constants have changed in handling from 3.8 and on. This PR attempts to unify the two and keep compatibility - with the current feature set.

The short of it is that `ast.Constant` exists in 3.6 but is not emitted until 3.8. This means that in 3.6 and 3.7 that strings/numbers generate `Num`/`Str`, whereas in 3.8, `ast.Constant` is used for both but differentiates by way of a Python object `.value`.

For me, Python 3.7 was previously hanging on `ppci.common.CompilerError: ('Cannot do <_ast.Str object at 0x1029e8a10>', (mandelbrot.py, 31, 10))` before this PR, and works successfully after. Looks like it's not covered in the test suite currently.