### PR TITLE
docs: Fix a few typos

### DIFF
--- a/ppci/arch/data_instructions.py
+++ b/ppci/arch/data_instructions.py
@@ -95,7 +95,7 @@ class U16DataRelocation(Relocation):
     field = "value"
 
     def calc(self, sym_value, reloc_value):
-        # The value of the symbol is not nessecarily aligned at two bytes.
+        # The value of the symbol is not necessarily aligned at two bytes.
         # assert sym_value % 2 == 0
         assert reloc_value % 2 == 0
         return sym_value

--- a/ppci/arch/runtime.py
+++ b/ppci/arch/runtime.py
@@ -1,4 +1,4 @@
-""" Runtime libraries for operations that some platforms do not supprt.
+""" Runtime libraries for operations that some platforms do not support.
 
 Examples of these are functions like __divsi3. This function performs a
 signed integer division.

--- a/ppci/lang/c/semantics.py
+++ b/ppci/lang/c/semantics.py
@@ -368,7 +368,7 @@ class CSemantics:
         return ctyp
 
     def on_typename(self, name, location):
-        """ Handle the case when a typedef is refered """
+        """ Handle the case when a typedef is referred """
         # Lookup typedef
         typedef = self.scope.get_identifier(name).declaration
         assert isinstance(typedef, declarations.Typedef)

--- a/ppci/wasm/components.py
+++ b/ppci/wasm/components.py
@@ -415,7 +415,7 @@ class Type(Definition):
 
     Flat form and abbreviations:
 
-    * In the flat form, a module has type definitions, and these are refered to
+    * In the flat form, a module has type definitions, and these are referred to
       with "type uses": ``(type $xx)``.
     * A type use can be given to *define* the type rather than reference it,
       this is resolved by the Module class.


### PR DESCRIPTION
There are small typos in:
- ppci/arch/data_instructions.py
- ppci/arch/runtime.py
- ppci/lang/c/semantics.py
- ppci/wasm/components.py

Fixes:
- Should read `support` rather than `supprt`.
- Should read `referred` rather than `refered`.
- Should read `necessarily` rather than `nessecarily`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md